### PR TITLE
Be clear about using 'tag' as rebar dependency.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,7 @@
 {deps, [
-{epgsql,".*",{git,"https://github.com/epgsql/epgsql","4.1.0"}},{ecpool,".*",{git,"https://github.com/emqx/ecpool","v0.3.0"}},{clique,".*",{git,"https://github.com/emqx/clique","v0.3.11"}},{emqx_passwd,".*",{git,"https://github.com/emqx/emqx-passwd","v1.0"}}
+{epgsql,".*",{git,"https://github.com/epgsql/epgsql",{tag, "4.1.0"}}},
+{ecpool,".*",{git,"https://github.com/emqx/ecpool",{tag, "v0.3.0"}}},
+{clique,".*",{git,"https://github.com/emqx/clique",{tag, "v0.3.11"}}},
+{emqx_passwd,".*",{git,"https://github.com/emqx/emqx-passwd",{tag, "v1.0"}}}
 ]}.
 {erl_opts, [debug_info]}.


### PR DESCRIPTION
This is to allow rebar3 to perform allow shallow clone with depth=1.
Otherwise if the version reference is not specific,
rebar3 would perform a shallow clone its default branch
then try git checkout on the given reference, which may not
exist if the tag is not on the exact latest commit of the
default branch